### PR TITLE
Safe javascript sending

### DIFF
--- a/android/src/main/java/com/nuttawutmalee/RCTBluetoothSerial/RCTBluetoothSerialModule.java
+++ b/android/src/main/java/com/nuttawutmalee/RCTBluetoothSerial/RCTBluetoothSerialModule.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.io.UnsupportedEncodingException;
 import javax.annotation.Nullable;
 
 import android.app.Activity;

--- a/android/src/main/java/com/nuttawutmalee/RCTBluetoothSerial/RCTBluetoothSerialModule.java
+++ b/android/src/main/java/com/nuttawutmalee/RCTBluetoothSerial/RCTBluetoothSerialModule.java
@@ -572,7 +572,7 @@ public class RCTBluetoothSerialModule extends ReactContextBaseJavaModule
 
     /**
      * Handle connection success
-     * 
+     *
      * @param msg             Additional message
      * @param connectedDevice Connected device
      */
@@ -605,7 +605,7 @@ public class RCTBluetoothSerialModule extends ReactContextBaseJavaModule
 
     /**
      * handle connection failure
-     * 
+     *
      * @param msg             Additional message
      * @param connectedDevice Connected device
      */
@@ -631,7 +631,7 @@ public class RCTBluetoothSerialModule extends ReactContextBaseJavaModule
 
     /**
      * Handle lost connection
-     * 
+     *
      * @param msg             Message
      * @param connectedDevice Connected device
      */
@@ -648,7 +648,7 @@ public class RCTBluetoothSerialModule extends ReactContextBaseJavaModule
 
     /**
      * Handle error
-     * 
+     *
      * @param e Exception
      */
     void onError(Exception e) {
@@ -677,16 +677,24 @@ public class RCTBluetoothSerialModule extends ReactContextBaseJavaModule
         }
 
         String completeData = readUntil(id, delimiter);
-
         if (completeData != null && completeData.length() > 0) {
+            String encodedData;
+            try {
+                encodedData = Base64.encodeToString(completeData.getBytes("ISO-8859-1"), Base64.DEFAULT);
+            } catch (UnsupportedEncodingException e) {
+                // Scream
+                this.onError(e);
+                return;
+            }
+
             WritableMap readParams = Arguments.createMap();
             readParams.putString("id", id);
-            readParams.putString("data", completeData);
+            readParams.putString("data", encodedData);
             sendEvent(DEVICE_READ, readParams);
 
             WritableMap dataParams = Arguments.createMap();
             dataParams.putString("id", id);
-            dataParams.putString("data", completeData);
+            dataParams.putString("data", encodedData);
             sendEvent(DATA_READ, dataParams);
         }
     }
@@ -717,7 +725,7 @@ public class RCTBluetoothSerialModule extends ReactContextBaseJavaModule
 
     /**
      * Check if is api level 19 or above
-     * 
+     *
      * @return is above api level 19
      */
     private boolean isKitKatOrAbove() {
@@ -726,7 +734,7 @@ public class RCTBluetoothSerialModule extends ReactContextBaseJavaModule
 
     /**
      * Send event to javascript
-     * 
+     *
      * @param eventName Name of the event
      * @param params    Additional params
      */
@@ -740,7 +748,7 @@ public class RCTBluetoothSerialModule extends ReactContextBaseJavaModule
 
     /**
      * Convert BluetoothDevice into WritableMap
-     * 
+     *
      * @param device Bluetooth device
      */
     private WritableMap deviceToWritableMap(BluetoothDevice device) {
@@ -764,7 +772,7 @@ public class RCTBluetoothSerialModule extends ReactContextBaseJavaModule
 
     /**
      * Pair device before kitkat
-     * 
+     *
      * @param device Device
      */
     private void pairDevice(BluetoothDevice device) {
@@ -786,7 +794,7 @@ public class RCTBluetoothSerialModule extends ReactContextBaseJavaModule
 
     /**
      * Unpair device
-     * 
+     *
      * @param device Device
      */
     private void unpairDevice(BluetoothDevice device) {
@@ -808,7 +816,7 @@ public class RCTBluetoothSerialModule extends ReactContextBaseJavaModule
 
     /**
      * Return reject promise for null bluetooth adapter
-     * 
+     *
      * @param promise
      */
     private void rejectNullBluetoothAdapter(Promise promise) {
@@ -820,7 +828,7 @@ public class RCTBluetoothSerialModule extends ReactContextBaseJavaModule
 
     /**
      * Register receiver for device pairing
-     * 
+     *
      * @param rawDevice     Bluetooth device
      * @param requiredState State that we require
      */

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const ReactNative = require("react-native");
 const React = require("react");
 const { Buffer } = require("buffer");
+const { decode } = require("base-64");
 
 const { NativeModules, DeviceEventEmitter } = ReactNative;
 const { BluetoothSerial } = NativeModules;
@@ -271,8 +272,17 @@ BluetoothSerial.once = (eventName, handler, context) =>
  * @param context - Optional context object to use when invoking the
  *   listener
  */
-BluetoothSerial.addListener = (eventName, handler, context) =>
-  DeviceEventEmitter.addListener(eventName, handler, context);
+BluetoothSerial.addListener = (eventName, handler, context) => {
+  if (eventName === 'data' || eventName === 'read') {
+    return DeviceEventEmitter.addListener(eventName, (event) => {
+      return handler({
+        id: event.id,
+        data: decode(event.data)
+      });
+    }, context);
+  }
+  return DeviceEventEmitter.addListener(eventName, handler, context);
+}
 
 /**
  * Attach listener to a certain event name.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "homepage": "https://nuttawutmalee.github.io/react-native-bluetooth-serial-next/",
   "dependencies": {
     "@babel/runtime": "^7.1.5",
-    "buffer": "^5.2.1"
+    "buffer": "^5.2.1",
+    "base-64": "^0.1.0"
   },
   "peerDependencies": {
     "react": "*",


### PR DESCRIPTION
This adds Base64 encoding to the receipt of Bluetooth events; it's only implemented on the Android half as that's all we need currently.  This allows strings with nulls in them to safely cross the Java/Javascript barrier.

The other Read actions are likely broken due to this, but as we aren't using them, 🤷‍♀️ 